### PR TITLE
Update RAI Lending Platform from v0.4 to v0.6

### DIFF
--- a/3-lending/rai-test/Cargo.toml
+++ b/3-lending/rai-test/Cargo.toml
@@ -4,11 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.4.1" }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.4.1" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.6.0" }
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.6.0" }
 
 [dev-dependencies]
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.4.1" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.6.0" }
+transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.6.0" } 
+scrypto-unit = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.6.0" }
 
 [profile.release]
 opt-level = 's'     # Optimize for size.
@@ -16,6 +18,7 @@ lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
 strip = "debuginfo" # Strip debug info.
+overflow-checks = true # Panic in the case of an overflow. 
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/3-lending/rai-test/dependencies/oracle_placeholder/Cargo.toml
+++ b/3-lending/rai-test/dependencies/oracle_placeholder/Cargo.toml
@@ -4,11 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.4.1" }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.4.1" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.6.0" } 
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.6.0" } 
 
 [dev-dependencies]
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.4.1" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.6.0" } 
+transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.6.0" } 
+scrypto-unit = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.6.0" } 
 
 [profile.release]
 opt-level = 's'     # Optimize for size.
@@ -16,6 +18,7 @@ lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
 strip = "debuginfo" # Strip debug info.
+overflow-checks = true # Panic in the case of an overflow. 
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/3-lending/rai-test/raitest.rev
+++ b/3-lending/rai-test/raitest.rev
@@ -1,3 +1,40 @@
+//reset
+//new-account -> act
+//show $act
+
+////publish ./dependencies/oracle_placeholder --manifest rtm/publish_oracle.rtm
+////call-function $oracle_package OraclePlaceholder new --manifest rtm/instantiate_oracle.rtm
+////publish . --manifest rtm/publish_rai_lending_platform.rtm
+////call-function $package RaiTest new $oracle_component --manifest rtm/instantiate_rai_lending_platform.rtm
+////call-method $component open_position 500,resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag --manifest rtm/open_position.rtm
+////call-method $component draw 1,$position 5 --manifest rtm/draw.rtm
+////call-method $component close_position_with_payment 1,$position 5,$rai --manifest rtm/close_position_with_payment.rtm
+
+//publish ./dependencies/oracle_placeholder -> oracle_package
+//call-function $oracle_package OraclePlaceholder new -> oracle_component
+
+//publish . -> package
+//call-function $package RaiTest new $oracle_component -> component adminbadge minterbadge position rai
+//call-method $component open_position 500,resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag
+//call-method $component draw 1,$position 5
+//call-method $component close_position_with_payment 1,$position 5,$rai
+
+//reset
+//new-account -> act
+//show $act
+//
+//publish ./dependencies/oracle_placeholder -> oracle_package
+//call-function $oracle_package OraclePlaceholder new -> oracle_component
+//
+//publish . -> package
+//call-function $package RaiTest new $oracle_component -> component adminbadge minterbadge position rai
+//call-method $component open_position 500,resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag
+//call-method $component draw 1,$position 5
+//set-current-epoch 15000
+//call-method $component paydown 1,$position 5,$rai
+//call-method $component add_collateral 1,$position 20,resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag
+//call-method $component partial_withdraw_collateral 1,$position 400
+
 reset
 new-account -> act
 
@@ -6,40 +43,13 @@ call-function $oracle_package OraclePlaceholder new -> oracle_component
 
 publish . -> package
 call-function $package RaiTest new $oracle_component -> component adminbadge minterbadge position rai
-call-method $component open_position 500,030000000000000000000000000000000000000000000000000004 
-call-method $component draw 1,$position 5
-call-method $component close_position_with_payment 1,$position 5,$rai
-
-reset
-new-account -> act
-
-publish ./dependencies/oracle_placeholder -> oracle_package
-call-function $oracle_package OraclePlaceholder new -> oracle_component
-
-publish . -> package
-call-function $package RaiTest new $oracle_component -> component adminbadge minterbadge position rai
-call-method $component open_position 500,030000000000000000000000000000000000000000000000000004 
-call-method $component draw 1,$position 5
+call-method $component open_position 50,resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag 
+call-method $component draw #0a0000000000000000,$position 3
 set-current-epoch 15000
-call-method $component paydown 1,$position 5,$rai
-call-method $component add_collateral 1,$position 20,030000000000000000000000000000000000000000000000000004
-call-method $component partial_withdraw_collateral 1,$position 400
-
-reset
-new-account -> act
-
-publish ./dependencies/oracle_placeholder -> oracle_package
-call-function $oracle_package OraclePlaceholder new -> oracle_component
-
-publish . -> package
-call-function $package RaiTest new $oracle_component -> component adminbadge minterbadge position rai
-call-method $component open_position 500,030000000000000000000000000000000000000000000000000004 
-call-method $component draw #0000000000000000,$position 30
-set-current-epoch 15000
-call-method $component open_position 1000,030000000000000000000000000000000000000000000000000004 
-call-method $component draw #0000000000000001,$position 50
+call-method $component open_position 100,resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag 
+call-method $component draw #0a0100000000000000,$position 5
 call-method $oracle_component set_price .075
-call-method $component liquidate 0000000000000000 50,$rai
+call-method $component liquidate 0a0000000000000000 5,$rai
 
 reset
 new-account -> act
@@ -49,15 +59,15 @@ call-function $oracle_package OraclePlaceholder new -> oracle_component
 
 publish . -> package
 call-function $package RaiTest new $oracle_component -> component adminbadge minterbadge position rai
-call-method $component open_position 500,030000000000000000000000000000000000000000000000000004 
-call-method $component draw #0000000000000000,$position 30
+call-method $component open_position 50,resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag 
+call-method $component draw #0a0000000000000000,$position 3
 set-current-epoch 15000
-call-method $component open_position 1000,030000000000000000000000000000000000000000000000000004 
-call-method $component draw #0000000000000001,$position 50
+call-method $component open_position 100,resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag 
+call-method $component draw #0a0100000000000000,$position 5
 call-method $oracle_component set_price .01
-call-method $component liquidate 0000000000000000 50,$rai
+call-method $component liquidate 0a0000000000000000 5,$rai
 call-method $component check_protocol_solvency
-call-method $component redeem 48.46186973689145765,$rai
+call-method $component redeem 4.846186973689139873,$rai
 
 reset
 new-account -> act
@@ -67,11 +77,11 @@ call-function $oracle_package OraclePlaceholder new -> oracle_component
 
 publish . -> package
 call-function $package RaiTest new $oracle_component -> component adminbadge minterbadge position rai
-call-method $component open_position 500,030000000000000000000000000000000000000000000000000004 
-call-method $component draw #0000000000000000,$position 33
+call-method $component open_position 50,resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag 
+call-method $component draw #0a0000000000000000,$position 3.3
 set-current-epoch 15000
-call-method $component open_position 1000,030000000000000000000000000000000000000000000000000004 
-call-method $component draw #0000000000000001,$position 50
-call-method $component open_position 2500,030000000000000000000000000000000000000000000000000004 
-call-method $component draw #0000000000000002,$position 100
+call-method $component open_position 100,resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag 
+call-method $component draw #0a0100000000000000,$position 5
+call-method $component open_position 250,resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag 
+call-method $component draw #0a0200000000000000,$position 10
 call-method $component print_all_positions


### PR DESCRIPTION
- There is a current nondetermistic bug with Decimal.powi() that happens sometimes when it is called several times, even with the same arguments. It can be reproduced by running the revup script (a wrapper around resim) raitest.rev. In the last print_all_positions call, it recalculates the current P&I and fails the transaction, even though the earlier liquidate method call (raitest.rev:68) calls powi with the same arguments and does not error out.